### PR TITLE
Scrollbar fix & improvement

### DIFF
--- a/src/Basescape/SoldierDiaryOverviewState.cpp
+++ b/src/Basescape/SoldierDiaryOverviewState.cpp
@@ -168,9 +168,10 @@ void SoldierDiaryOverviewState::init()
 	_soldier = _list->at(_soldierId);
 	_txtTitle->setText(_soldier->getName());
 	_lstDiary->clearList();
-	_lstDiary->scrollTo(0);
+	
 	std::vector<MissionStatistics*> *missionStatistics = _game->getSavedGame()->getMissionStatistics();
 
+	int row = 0;
 	for (std::vector<MissionStatistics*>::iterator j = missionStatistics->begin() ; j != missionStatistics->end() ; ++j)
 	{
 		int missionId = (*j)->id;
@@ -226,6 +227,11 @@ void SoldierDiaryOverviewState::init()
 		wssStatus << wssSuccess.str().c_str() << " - " << wssRating.str().c_str();
 		
 		_lstDiary->addRow(5, wssLocation.str().c_str(), wssStatus.str().c_str(), wssDay.str().c_str(), wssMonth.str().c_str(), wssYear.str().c_str());
+		row++;
+	}
+	if (row > 0 && _lstDiary->getScroll() >= row)
+	{
+		_lstDiary->scrollTo(0);
 	}
 }
 


### PR DESCRIPTION
Makes diary mission list maintain position after viewing a mission log and fixes crash when selecting a mission in the diary for a soldier with more than 15.
